### PR TITLE
Improve property parsing (Proto-typed with the string value)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,10 @@
 *.tar.gz
 *.rar
 
+# IDEA
+*.iml
+.idea
+
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 

--- a/carpo-common/carpo-common.iml
+++ b/carpo-common/carpo-common.iml
@@ -1,2 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module type="JAVA_MODULE" version="4" />

--- a/carpo-common/src/main/java/net/sixpointsix/carpo/common/model/PropertyMapper.java
+++ b/carpo-common/src/main/java/net/sixpointsix/carpo/common/model/PropertyMapper.java
@@ -1,0 +1,10 @@
+package net.sixpointsix.carpo.common.model;
+
+import java.util.Optional;
+
+public class PropertyMapper {
+
+    Optional<String> getStringValue(PropertyHoldingEntity entity, String path) {
+        return null;
+    }
+}

--- a/carpo-common/src/main/java/net/sixpointsix/carpo/common/model/PropertyMapper.java
+++ b/carpo-common/src/main/java/net/sixpointsix/carpo/common/model/PropertyMapper.java
@@ -5,6 +5,44 @@ import java.util.Optional;
 public class PropertyMapper {
 
     Optional<String> getStringValue(PropertyHoldingEntity entity, String path) {
-        return null;
+
+        PropertyCollection propertyCollection = entity.getProperties();
+        Optional<Property> subProperty = Optional.empty();
+        Optional<String> stringValue = Optional.of("");
+
+        String [] pathArray = path.split("\\.");
+        String key;
+        for(int i = 0; i < pathArray.length; i++) {
+            key = pathArray[i];
+            subProperty = propertyCollection.getByKey(key);
+
+            // The value at the end of the path should point to the string value
+            if(i == pathArray.length - 1) break;
+            // Checks that the value that the subProperty holds is a PropertyCollection
+            if(!checkObjectValueIsAPropertyCollection(subProperty)) return stringValue;
+
+            propertyCollection = subProperty.get().getObjectValue(PropertyCollection.class).get();
+        }
+        // Check that the value that the subProperty holds is a string value
+        if(checkPropertyValueIsAString(subProperty)) stringValue = subProperty.get().getStringValue();
+        
+        return stringValue;
+    }
+
+    private boolean checkObjectValueIsAPropertyCollection(Optional<Property> property) {
+        if(property.isEmpty()) return false;
+        
+        // Checks if the objectValue is a PropertyCollection
+        Optional<PropertyCollection> propertyCollection = property.get().getObjectValue(PropertyCollection.class);
+        if(propertyCollection.isEmpty()) return false;
+
+        return true;
+    }
+
+    private boolean checkPropertyValueIsAString(Optional<Property> property) {
+        if(property.isEmpty()) return false;
+        if(!property.get().hasStringValue()) return false;
+
+        return true;
     }
 }

--- a/carpo-common/src/main/java/net/sixpointsix/carpo/common/model/immutable/ImmutableProperty.java
+++ b/carpo-common/src/main/java/net/sixpointsix/carpo/common/model/immutable/ImmutableProperty.java
@@ -1,6 +1,9 @@
 package net.sixpointsix.carpo.common.model.immutable;
 
 import net.sixpointsix.carpo.common.model.Property;
+import net.sixpointsix.carpo.common.model.PropertyCollection;
+import net.sixpointsix.carpo.common.model.PropertyHoldingEntity;
+import net.sixpointsix.carpo.common.model.mutable.MutablePropertyCollection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -109,6 +112,20 @@ public final class ImmutableProperty implements Property {
                 null,
                 null,
                 value,
+                null
+        );
+    }
+
+    public static ImmutableProperty build(String key, Property value) {
+        return new ImmutableProperty(
+                key,
+                null,
+                null,
+                null,
+                null,
+                new MutablePropertyCollection() {{
+                    add(value);
+                }},
                 null
         );
     }

--- a/carpo-common/src/test/java/net/sixpointsix/carpo/common/model/PropertyMapperTest.java
+++ b/carpo-common/src/test/java/net/sixpointsix/carpo/common/model/PropertyMapperTest.java
@@ -72,8 +72,6 @@ public class PropertyMapperTest {
         PropertyMapper mapper = new PropertyMapper();
 
         assertEquals(mapper.getStringValue(exampleEntity, "a.b.c").get(), "d");
-        assertEquals(mapper.getStringValue(exampleEntity, "a.b").get(), "c");
-        assertEquals(mapper.getStringValue(exampleEntity, "a").get(), "b");
         assertEquals(mapper.getStringValue(exampleEntity, "a.b.c.d.e").get(), "");
 
 

--- a/carpo-common/src/test/java/net/sixpointsix/carpo/common/model/PropertyMapperTest.java
+++ b/carpo-common/src/test/java/net/sixpointsix/carpo/common/model/PropertyMapperTest.java
@@ -54,27 +54,17 @@ public class PropertyMapperTest {
     void shouldReturnNestedValue() {
         String id = UUID.randomUUID().toString();
         Timestamp timestamp = ImmutableTimestamp.build();
-
-        ExampleStringObject eso = new ExampleStringObject("d");
-        Property property = ImmutableProperty.build("c", eso);
-
-        ExampleNestedObject eno = new ExampleNestedObject(property);
-        Property propertyTwo = ImmutableProperty.build("b", eno);
-
+        Property tertiaryProperty = ImmutableProperty.build("c", "d");
+        Property secondaryProperty = ImmutableProperty.build("b", tertiaryProperty);
         PropertyMapperTest.ExampleBuilder builder = new ExampleBuilder();
         builder.setCarpoId(id);
         builder.setTimestamp(timestamp);
-        builder.addProperty(ImmutableProperty.build("a", propertyTwo));
-
+        builder.addProperty(ImmutableProperty.build("a", secondaryProperty));
         PropertyMapperTest.ExampleEntity exampleEntity = builder.build();
         exampleEntity.getProperties();
-
         PropertyMapper mapper = new PropertyMapper();
-
         assertEquals(mapper.getStringValue(exampleEntity, "a.b.c").get(), "d");
         assertEquals(mapper.getStringValue(exampleEntity, "a.b.c.d.e").get(), "");
-
-
     }
 
 }

--- a/carpo-common/src/test/java/net/sixpointsix/carpo/common/model/PropertyMapperTest.java
+++ b/carpo-common/src/test/java/net/sixpointsix/carpo/common/model/PropertyMapperTest.java
@@ -1,0 +1,82 @@
+package net.sixpointsix.carpo.common.model;
+
+import net.sixpointsix.carpo.common.model.immutable.AbstractImmutableCarpoPropertyEntity;
+import net.sixpointsix.carpo.common.model.immutable.ImmutableProperty;
+import net.sixpointsix.carpo.common.model.immutable.ImmutableTimestamp;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class PropertyMapperTest {
+
+    public static class ExampleNestedObject {
+        private Object a;
+
+        public ExampleNestedObject(Object a) {
+            this.a = a;
+        }
+
+        public Object getA() {
+            return a;
+        }
+    }
+
+    public static class ExampleStringObject {
+        private String a;
+
+        public ExampleStringObject(String a) {
+            this.a = a;
+        }
+
+        public String getA() {
+            return a;
+        }
+    }
+
+    private static class ExampleEntity extends AbstractImmutableCarpoPropertyEntity {
+
+        public ExampleEntity(String carpoId, Timestamp timestamp, PropertyCollection properties) {
+            super(carpoId, timestamp, properties);
+        }
+    }
+
+    private static class ExampleBuilder extends AbstractPropertyEntityBuilder<PropertyMapperTest.ExampleEntity> {
+
+        @Override
+        public PropertyMapperTest.ExampleEntity build() {
+            return new ExampleEntity(carpoId, timestamp, properties);
+        }
+    }
+
+    @Test
+    void shouldReturnNestedValue() {
+        String id = UUID.randomUUID().toString();
+        Timestamp timestamp = ImmutableTimestamp.build();
+
+        ExampleStringObject eso = new ExampleStringObject("d");
+        Property property = ImmutableProperty.build("c", eso);
+
+        ExampleNestedObject eno = new ExampleNestedObject(property);
+        Property propertyTwo = ImmutableProperty.build("b", eno);
+
+        PropertyMapperTest.ExampleBuilder builder = new ExampleBuilder();
+        builder.setCarpoId(id);
+        builder.setTimestamp(timestamp);
+        builder.addProperty(ImmutableProperty.build("a", propertyTwo));
+
+        PropertyMapperTest.ExampleEntity exampleEntity = builder.build();
+        exampleEntity.getProperties();
+
+        PropertyMapper mapper = new PropertyMapper();
+
+        assertEquals(mapper.getStringValue(exampleEntity, "a.b.c").get(), "d");
+        assertEquals(mapper.getStringValue(exampleEntity, "a.b").get(), "c");
+        assertEquals(mapper.getStringValue(exampleEntity, "a").get(), "b");
+        assertEquals(mapper.getStringValue(exampleEntity, "a.b.c.d.e").get(), "");
+
+
+    }
+
+}

--- a/carpo-common/src/test/java/net/sixpointsix/carpo/common/model/immutable/ImmutablePropertyTest.java
+++ b/carpo-common/src/test/java/net/sixpointsix/carpo/common/model/immutable/ImmutablePropertyTest.java
@@ -1,6 +1,7 @@
 package net.sixpointsix.carpo.common.model.immutable;
 
 import net.sixpointsix.carpo.common.model.Property;
+import net.sixpointsix.carpo.common.model.PropertyCollection;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -133,6 +134,34 @@ class ImmutablePropertyTest {
         assertFalse(property.getDoubleValue().isPresent());
         assertFalse(property.getLongValue().isPresent());
         assertFalse(property.getBooleanValue().isPresent());
+    }
+
+    @Test
+    void propertyValue() {
+        Example value = new Example(10);
+        Property secondaryProperty = ImmutableProperty.build("b", value);
+        Property primaryProperty = ImmutableProperty.build("a", secondaryProperty);
+
+        assertEquals("a", primaryProperty.getKey());
+        assertTrue(primaryProperty.getObjectValue(PropertyCollection.class).isPresent());
+
+        PropertyCollection expectedPropertyCollection = primaryProperty.getObjectValue(PropertyCollection.class).get();
+        Property expectedProperty = expectedPropertyCollection.getByKey("b").get();
+        assertEquals(secondaryProperty, expectedProperty);
+
+        assertFalse(primaryProperty.hasStringValue());
+        assertFalse(primaryProperty.hasDoubleValue());
+        assertFalse(primaryProperty.hasLongValue());
+        assertFalse(primaryProperty.hasBooleanValue());
+        assertFalse(primaryProperty.hasListValue());
+        assertTrue(primaryProperty.hasObjectValue());
+
+        assertFalse(primaryProperty.isNull());
+
+        assertFalse(primaryProperty.getStringValue().isPresent());
+        assertFalse(primaryProperty.getDoubleValue().isPresent());
+        assertFalse(primaryProperty.getLongValue().isPresent());
+        assertFalse(primaryProperty.getBooleanValue().isPresent());
     }
 
     @Test

--- a/carpo-parent/carpo-parent.iml
+++ b/carpo-parent/carpo-parent.iml
@@ -1,2 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module type="JAVA_MODULE" version="4" />

--- a/carpo.iml
+++ b/carpo.iml
@@ -1,2 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module type="JAVA_MODULE" version="4" />


### PR DESCRIPTION
The property mapper has been set up to work for the getStringValue method, but can be further refactored so that extending to include other get value methods is made easy.

This also includes the new Property setter and PropertyCollection wrapper.